### PR TITLE
Potential fix for code scanning alert no. 2: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/phpstan.yml
+++ b/.github/workflows/phpstan.yml
@@ -10,6 +10,8 @@ on:
 jobs:
   phpstan:
     name: phpstan
+    permissions:
+      contents: read
     runs-on: ubuntu-latest
     timeout-minutes: 5
     steps:


### PR DESCRIPTION
Potential fix for [https://github.com/step2dev/lazy-setting/security/code-scanning/2](https://github.com/step2dev/lazy-setting/security/code-scanning/2)

To fix the problem, you should add a `permissions` block to the workflow to explicitly restrict the permissions granted to the GITHUB_TOKEN. Since the workflow only needs to read repository contents (to check out code and run static analysis), the minimal required permission is `contents: read`. This block can be added either at the root of the workflow (to apply to all jobs) or at the job level. In this case, adding it at the job level (under `jobs.phpstan`) is sufficient and aligns with the CodeQL suggestion. No additional imports or definitions are needed; simply insert the `permissions` block with `contents: read` under the `phpstan` job.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
